### PR TITLE
fix: recomend format

### DIFF
--- a/cmd/applicationscan/recommend.go
+++ b/cmd/applicationscan/recommend.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/mattn/godown"
@@ -13,6 +14,8 @@ type recommend struct {
 	Recommendation string `json:"recommendation,omitempty"`
 }
 
+var multiLine = regexp.MustCompile("[\n]+")
+
 func getRecommend(alert *zapResultAlert) *recommend {
 	var r string
 	var buf bytes.Buffer
@@ -20,7 +23,7 @@ func getRecommend(alert *zapResultAlert) *recommend {
 		appLogger.Warnf("Failed to convert markdown from html, err=%+v, input=%s", err, alert.Solution)
 		r = alert.Solution
 	} else {
-		r = strings.TrimSpace(buf.String())
+		r = multiLine.ReplaceAllString(strings.TrimSpace(buf.String()), "\n")
 	}
 
 	return &recommend{

--- a/cmd/applicationscan/recommend_test.go
+++ b/cmd/applicationscan/recommend_test.go
@@ -39,6 +39,26 @@ func TestGetRecommend(t *testing.T) {
 * 2`,
 			},
 		},
+		{
+			name:  "OK/multi line format1",
+			input: &zapResultAlert{Alert: "alert", RiskDesc: "desc", RiskCode: "1", Solution: "<p>1</p><p>2</p>"},
+			want: &recommend{
+				Risk: `alert
+		- Risk: desc <risk_code: 1>`,
+				Recommendation: `1
+2`,
+			},
+		},
+		{
+			name:  "OK/multi line format2",
+			input: &zapResultAlert{Alert: "alert", RiskDesc: "desc", RiskCode: "1", Solution: `1<br /><br /><br /><br />2`},
+			want: &recommend{
+				Risk: `alert
+		- Risk: desc <risk_code: 1>`,
+				Recommendation: `1
+2`,
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
HTMLをMarkdownドキュメントに変換する処理で、空改行が多すぎて可読性が落ちてしまう問題がありました。
空改行を整形する修正を入れます