### PR TITLE
Use common base image

### DIFF
--- a/cmd/diagnosis/Dockerfile
+++ b/cmd/diagnosis/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.16 as builder
 WORKDIR /go/src/github.com/ca-risken/diagnosis/diagnosis
 
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -12,15 +11,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp diagnosis /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-  && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 COPY --from=builder /go/bin/diagnosis /usr/local/diagnosis/bin/
 ENV PORT=19001 \
   DB_MASTER_HOST= \

--- a/cmd/jira/Dockerfile
+++ b/cmd/jira/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/ca-risken/diagnosis/src/jira/
 
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -12,15 +11,7 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp jira /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-  && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 COPY --from=builder /go/bin/jira /usr/local/jira/bin/
 ENV AWS_REGION= \
   AWS_ACCESS_KEY_ID= \

--- a/cmd/portscan/Dockerfile
+++ b/cmd/portscan/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/ca-risken/diagnosis/cmd/portscan/
 
 ADD *.go go.* ./
-ENV CGO_ENABLED=0 GOPRIVATE="github.com/CyberAgent/*,github.com/ca-risken/*"
-ARG ENV_INJECTOR_VERSION=v0.0.6
+ENV CGO_ENABLED=0 GOPRIVATE="github.com/ca-risken/*"
 ARG GITHUB_USER
 ARG GITHUB_TOKEN
 RUN echo "machine github.com" > ~/.netrc
@@ -12,15 +11,8 @@ RUN echo "login $GITHUB_USER" >> ~/.netrc
 RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go build && cp portscan /go/bin/
 
-WORKDIR /go/src/github.com/gassara-kys
-RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
-  && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
-
-FROM alpine
-RUN apk add --no-cache ca-certificates tzdata nmap nmap-scripts
-COPY --from=builder /go/bin/env-injector /usr/local/bin/
+FROM public.ecr.aws/risken/base/risken-base:v0.0.1
+RUN apk add --no-cache nmap nmap-scripts
 COPY --from=builder /go/bin/portscan /usr/local/portscan/bin/
 ENV DEBUG= \
   AWS_REGION= \


### PR DESCRIPTION
applicationscanとwpscanのアプリ以外がインストール済みのベースイメージを作ってそれを使うようにする
ビルドが遅いようなら、nmapのインストール済みのイメージを作る