### PR TITLE
rm: fixed RESULT_PATH

### DIFF
--- a/cmd/wpscan/Dockerfile
+++ b/cmd/wpscan/Dockerfile
@@ -20,8 +20,7 @@ RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_
 
 FROM public.ecr.aws/risken/risken-diagnosis/wpscan-base:v3.8.18
 USER root 
-RUN apk add --no-cache ca-certificates tzdata \
-  && mkdir /results
+RUN apk add --no-cache ca-certificates tzdata
 COPY --from=builder /go/bin/env-injector /usr/local/bin/
 COPY --from=builder /go/bin/wpscan /usr/local/wpscan/bin/
 ENV PORT=19003 \
@@ -41,7 +40,7 @@ ENV PORT=19003 \
   FINDING_SVC_ADDR= \
   ALERT_SVC_ADDR= \
   DIAGNOSIS_SVC_ADDR= \
-  RESULT_PATH=/results \
+  RESULT_PATH= \
   WPSCAN_VULNDB_APIKEY= \
   TZ=Asia/Tokyo
 


### PR DESCRIPTION
wpscanにSecurityContextの設定をいれるための準備として、Rootユーザ以外での実行できる状態にアプリケーションを修正します
- Root以外で実行すると、 /result への書き込み権限がないという旨のエラーを確認
  - デフォルト値が/tmpに指定されているのでそれを利用するように修正（エラー解消も確認）
- エラー発生時の調査が難しいため、コマンド実行時の標準出力・標準エラー出力をログにはくように修正
- `-wp-content-dir` の最初の一文字目がハイフンではなく別の文字になっていたので修正
  - 以下のWarnigが出ていました
```
文字 U+2013 "–"は、ソース コードでより一般的な文字U+002d "-"と混同される可能性があります。
```

関連: https://github.com/ca-risken/internal-community/issues/176