### PR TITLE
use: common datasource name

### DIFF
--- a/pkg/common/datasource.go
+++ b/pkg/common/datasource.go
@@ -1,0 +1,7 @@
+package common
+
+const (
+	DataSourceNameWPScan          = "diagnosis:wpscan"
+	DataSourceNamePortScan        = "diagnosis:portscan"
+	DataSourceNameApplicationScan = "diagnosis:application-scan"
+)


### PR DESCRIPTION
datasource名をgRPCサーバーでもワーカーサービスでも共通のものを利用したいのでパッケージに切り出します。