### PR TITLE
Fix-wpscan

### DIFF
--- a/cmd/wpscan/finding.go
+++ b/cmd/wpscan/finding.go
@@ -131,7 +131,7 @@ func getVersionFinding(wpScanVersion version, message *message.WpscanQueueMessag
 	findingInf, ok := wpscanFindingMap[findingType]
 	if !ok {
 		appLogger.Warnf("Failed to get finding information, Unknown findingType=%v", findingType)
-		return nil, nil, nil
+		return nil, nil, fmt.Errorf("failed to get access information. findingType=%v", findingType)
 	}
 	data, err := json.Marshal(map[string]version{"data": wpScanVersion})
 	if err != nil {
@@ -177,8 +177,8 @@ func getAccessFinding(access []*checkAccess, isUserFound bool, message *message.
 	}
 
 	if !ok {
-		appLogger.Warnf("Failed to get access information, Unknown isFoundAccesibleURL=%v, isUserFound=%v", isFoundAccesibleURL, isUserFound)
-		return nil, nil, nil
+		appLogger.Warnf("Failed to get access information, isFoundAccesibleURL=%v, isUserFound=%v", isFoundAccesibleURL, isUserFound)
+		return nil, nil, fmt.Errorf("failed to get access information. isFoundAccesibleURL=%v, isUserFound=%v", isFoundAccesibleURL, isUserFound)
 	}
 	f := makeFinding(findingInf.Description, fmt.Sprintf("Accesible_%v", message.TargetURL), findingInf.Score, &data, message)
 	if zero.IsZeroVal(findingInf.Risk) || zero.IsZeroVal(findingInf.Recommendation) {

--- a/cmd/wpscan/finding_test.go
+++ b/cmd/wpscan/finding_test.go
@@ -436,7 +436,7 @@ func TestGetPluginFinding(t *testing.T) {
 func TestGetAccessFinding(t *testing.T) {
 	cases := []struct {
 		name        string
-		access      []*checkAccess
+		access      *checkAccess
 		isUserFound bool
 		dataString  string
 		message     *message.WpscanQueueMessage
@@ -446,13 +446,15 @@ func TestGetAccessFinding(t *testing.T) {
 	}{
 		{
 			name: "Closed no recommend",
-			access: []*checkAccess{{
-				Target:   "target",
-				Goal:     "goal",
-				Method:   "GET",
-				Type:     "Login",
-				IsAccess: false,
-			}},
+			access: &checkAccess{
+				Target: []checkAccessTarget{
+					{URL: "target",
+						Goal:         "goal",
+						Method:       "GET",
+						IsAccessible: false,
+					}},
+				isFoundAccesibleURL: false,
+			},
 			message: &message.WpscanQueueMessage{
 				DataSource:      common.DataSourceNameWPScan,
 				WpscanSettingID: 1,
@@ -469,20 +471,22 @@ func TestGetAccessFinding(t *testing.T) {
 				ProjectId:        1,
 				OriginalScore:    1.0,
 				OriginalMaxScore: 10.0,
-				Data:             "[{\"is_accessible\":false,\"url\":\"target\"}]",
+				Data:             "{\"Target\":[{\"URL\":\"target\",\"IsAccessible\":false}]}",
 			},
 			recommend: nil,
 			wantErr:   false,
 		},
 		{
 			name: "Open exists recommend",
-			access: []*checkAccess{{
-				Target:   "target",
-				Goal:     "goal",
-				Method:   "GET",
-				Type:     "Login",
-				IsAccess: true,
-			}},
+			access: &checkAccess{
+				Target: []checkAccessTarget{
+					{URL: "target",
+						Goal:         "goal",
+						Method:       "GET",
+						IsAccessible: true,
+					}},
+				isFoundAccesibleURL: true,
+			},
 			message: &message.WpscanQueueMessage{
 				DataSource:      common.DataSourceNameWPScan,
 				WpscanSettingID: 1,
@@ -499,7 +503,7 @@ func TestGetAccessFinding(t *testing.T) {
 				ProjectId:        1,
 				OriginalScore:    8.0,
 				OriginalMaxScore: 10.0,
-				Data:             "[{\"is_accessible\":true,\"url\":\"target\"}]",
+				Data:             "{\"Target\":[{\"URL\":\"target\",\"IsAccessible\":true}]}",
 			},
 			recommend: &finding.PutRecommendRequest{
 				ProjectId:  1,

--- a/cmd/wpscan/wpscan.go
+++ b/cmd/wpscan/wpscan.go
@@ -154,7 +154,7 @@ type wpscanOptions struct {
 
 type wpscanResult struct {
 	InterestingFindings []interestingFindings  `json:"interesting_findings"`
-	Version             version                `json:"version"`
+	Version             *version               `json:"version"`
 	Maintheme           mainTheme              `json:"main_theme"`
 	Users               map[string]interface{} `json:"users"`
 	CheckAccess         *checkAccess
@@ -207,6 +207,7 @@ type vulnAPI struct {
 type checkAccess struct {
 	Target              []checkAccessTarget
 	isFoundAccesibleURL bool
+	isUserFound         bool
 }
 
 type checkAccessTarget struct {


### PR DESCRIPTION
以前のPRへのコメント対応です。

commit **return error when cannot get finding information**
他のworkerと動作を揃えるためバージョン、アクセス情報を取得できない場合にエラーを返却する

commit **fix checkAccess**
getFindingからFindingとRecommend取得を分けるための前処理です。

commit **separate getFinding**
各getFinding関数をFinding,Recommend両方取得する形から個別に取得する形に修正します