### PR TITLE
Integrate log and trace in rpc

### DIFF
--- a/cmd/diagnosis/backend_sqs.go
+++ b/cmd/diagnosis/backend_sqs.go
@@ -62,17 +62,17 @@ func (s *sqsClient) sendWpscanMessage(ctx context.Context, msg *message.WpscanQu
 	}
 	buf, err := json.Marshal(msg)
 	if err != nil {
-		appLogger.Errorf("Failed to parse message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to parse message, error: %v", err)
 		return nil, fmt.Errorf("Failed to parse message, err=%+v", err)
 	}
-	appLogger.Infof("Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
+	appLogger.Infof(ctx, "Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
 	resp, err := s.svc.SendMessageWithContext(ctx, &sqs.SendMessageInput{
 		MessageBody:  aws.String(string(buf)),
 		QueueUrl:     &url,
 		DelaySeconds: aws.Int64(1),
 	})
 	if err != nil {
-		appLogger.Errorf("Failed to send message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to send message, error: %v", err)
 		return nil, err
 	}
 	return resp, nil
@@ -85,17 +85,17 @@ func (s *sqsClient) sendPortscanMessage(ctx context.Context, msg *message.Portsc
 	}
 	buf, err := json.Marshal(msg)
 	if err != nil {
-		appLogger.Errorf("Failed to parse message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to parse message, error: %v", err)
 		return nil, fmt.Errorf("Failed to parse message, err=%+v", err)
 	}
-	appLogger.Infof("Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
+	appLogger.Infof(ctx, "Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
 	resp, err := s.svc.SendMessageWithContext(ctx, &sqs.SendMessageInput{
 		MessageBody:  aws.String(string(buf)),
 		QueueUrl:     &url,
 		DelaySeconds: aws.Int64(1),
 	})
 	if err != nil {
-		appLogger.Errorf("Failed to send message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to send message, error: %v", err)
 		return nil, err
 	}
 	return resp, nil
@@ -108,17 +108,17 @@ func (s *sqsClient) sendApplicationScanMessage(ctx context.Context, msg *message
 	}
 	buf, err := json.Marshal(msg)
 	if err != nil {
-		appLogger.Errorf("Failed to parse message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to parse message, error: %v", err)
 		return nil, fmt.Errorf("Failed to parse message, err=%+v", err)
 	}
-	appLogger.Infof("Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
+	appLogger.Infof(ctx, "Send message, MessageBody: %v, QueueURL: %v", string(buf), url)
 	resp, err := s.svc.SendMessageWithContext(ctx, &sqs.SendMessageInput{
 		MessageBody:  aws.String(string(buf)),
 		QueueUrl:     &url,
 		DelaySeconds: aws.Int64(1),
 	})
 	if err != nil {
-		appLogger.Errorf("Failed to send message, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to send message, error: %v", err)
 		return nil, err
 	}
 	return resp, nil

--- a/cmd/diagnosis/client.go
+++ b/cmd/diagnosis/client.go
@@ -14,7 +14,7 @@ func newProjectClient(svcAddr string) project.ProjectServiceClient {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf("Faild to get GRPC connection: err=%+v", err)
+		appLogger.Fatalf(ctx, "Faild to get GRPC connection: err=%+v", err)
 	}
 	return project.NewProjectServiceClient(conn)
 }

--- a/cmd/diagnosis/go.mod
+++ b/cmd/diagnosis/go.mod
@@ -5,9 +5,9 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.41.3
 	github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097
-	github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27
-	github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b
+	github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097
 	github.com/ca-risken/core/proto/project v0.0.0-20220127020945-063d14f397ed
 	github.com/ca-risken/diagnosis/pkg/common v0.0.0-20220407095309-105129776296
@@ -50,7 +50,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
-	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/cmd/diagnosis/go.sum
+++ b/cmd/diagnosis/go.sum
@@ -103,10 +103,14 @@ github.com/ca-risken/common/pkg/database v0.0.0-20220421051518-d57cbf184097/go.m
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113014249-f285e209578f/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b h1:3Mn6kwDX2mISoCGdF/eYcfpGS0m6d17Z8t8HSl6s1bQ=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:dmZZ5/wkGbsmAMbhuC7YK6uJOMAlS4OndoM0DQyPhi8=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd h1:YXyIsRQNxpjNT3QaqYSU/RW7nA8HWh66EIE69yc0w/I=
+github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27 h1:NV95obXJwovUBvxWPW5boJcMAwkUIrsqhH3uwhTfTNY=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220304031727-c94e2c463b27/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b h1:Bku8qY0JoN4u+OgnFF+t5rzdgi7zp3e1vWL088g+cnQ=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220113015330-0e8462d52b5b/go.mod h1:A5WmKMV58G2v1s/oNXIzFsd9SiS8YxkkEWT3U6+yPd0=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd h1:rrkuvylG4Etubw0miHpNnWje4VR5ZPUGR8FPmJWNwck=
+github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd/go.mod h1:fnvFF8ESVirs5LV36leyFKf3FbuqjLDhJnipGJgDZtA=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097 h1:kz1mALLbChWS0inQct+rQUpTgCEM5+XL5bzIjmMguF8=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220421051518-d57cbf184097/go.mod h1:PIXjETIPseBEB/OXp5Rxn8FFuRwfQjFZe1VN+0Skh2E=
 github.com/ca-risken/core/proto/project v0.0.0-20220127020945-063d14f397ed h1:pOWNxFvFncNe24u0W3FMRLCdva0SQ7G0O0zs735+rq0=
@@ -976,6 +980,8 @@ golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/cmd/diagnosis/main.go
+++ b/cmd/diagnosis/main.go
@@ -127,8 +127,8 @@ func main() {
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			grpcmiddleware.ChainUnaryServer(
-				mimosarpc.LoggingUnaryServerInterceptor(appLogger),
-				grpctrace.UnaryServerInterceptor())))
+				grpctrace.UnaryServerInterceptor(),
+				mimosarpc.LoggingUnaryServerInterceptor(appLogger))))
 	diagnosis.RegisterDiagnosisServiceServer(server, service)
 
 	reflection.Register(server) // enable reflection API

--- a/cmd/diagnosis/services_application_scan.go
+++ b/cmd/diagnosis/services_application_scan.go
@@ -23,7 +23,7 @@ func (s *DiagnosisService) ListApplicationScan(ctx context.Context, req *diagnos
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListApplicationScanResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List ApplicationScan, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List ApplicationScan, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListApplicationScanResponse{}
@@ -40,7 +40,7 @@ func (s *DiagnosisService) GetApplicationScan(ctx context.Context, req *diagnosi
 	getData, err := s.repository.GetApplicationScan(ctx, req.ProjectId, req.ApplicationScanId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get ApplicationScan, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get ApplicationScan, error: %v", err)
 		return nil, err
 	}
 
@@ -54,7 +54,7 @@ func (s *DiagnosisService) PutApplicationScan(ctx context.Context, req *diagnosi
 	savedData, err := s.repository.GetApplicationScan(ctx, req.ProjectId, req.ApplicationScan.ApplicationScanId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get ApplicationScan, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get ApplicationScan, error: %v", err)
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (s *DiagnosisService) PutApplicationScan(ctx context.Context, req *diagnosi
 
 	registerdData, err := s.repository.UpsertApplicationScan(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put ApplicationScan, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put ApplicationScan, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutApplicationScanResponse{ApplicationScan: convertApplicationScan(registerdData)}, nil
@@ -86,7 +86,7 @@ func (s *DiagnosisService) DeleteApplicationScan(ctx context.Context, req *diagn
 		return nil, err
 	}
 	if err := s.repository.DeleteApplicationScan(ctx, req.ProjectId, req.ApplicationScanId); err != nil {
-		appLogger.Errorf("Failed to Delete ApplicationScan, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete ApplicationScan, error: %v", err)
 		return nil, err
 	}
 	// Delete ApplicationScanBasicSetting
@@ -106,7 +106,7 @@ func (s *DiagnosisService) ListApplicationScanBasicSetting(ctx context.Context, 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListApplicationScanBasicSettingResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List ApplicationScanBasicSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List ApplicationScanBasicSetting, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListApplicationScanBasicSettingResponse{}
@@ -123,7 +123,7 @@ func (s *DiagnosisService) GetApplicationScanBasicSetting(ctx context.Context, r
 	getData, err := s.repository.GetApplicationScanBasicSetting(ctx, req.ProjectId, req.ApplicationScanId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get ApplicationScanBasicSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get ApplicationScanBasicSetting, error: %v", err)
 		return nil, err
 	}
 
@@ -146,7 +146,7 @@ func (s *DiagnosisService) PutApplicationScanBasicSetting(ctx context.Context, r
 
 	registerdData, err := s.repository.UpsertApplicationScanBasicSetting(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put ApplicationScanBasicSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put ApplicationScanBasicSetting, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutApplicationScanBasicSettingResponse{ApplicationScanBasicSetting: convertApplicationScanBasicSetting(registerdData)}, nil
@@ -157,7 +157,7 @@ func (s *DiagnosisService) DeleteApplicationScanBasicSetting(ctx context.Context
 		return nil, err
 	}
 	if err := s.repository.DeleteApplicationScanBasicSetting(ctx, req.ProjectId, req.ApplicationScanBasicSettingId); err != nil {
-		appLogger.Errorf("Failed to Delete ApplicationScanBasicSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete ApplicationScanBasicSetting, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/cmd/diagnosis/services_diagnosis_data_source.go
+++ b/cmd/diagnosis/services_diagnosis_data_source.go
@@ -19,7 +19,7 @@ func (s *DiagnosisService) ListDiagnosisDataSource(ctx context.Context, req *dia
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListDiagnosisDataSourceResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List DiagnosisDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List DiagnosisDataSource, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListDiagnosisDataSourceResponse{}
@@ -36,7 +36,7 @@ func (s *DiagnosisService) GetDiagnosisDataSource(ctx context.Context, req *diag
 	getData, err := s.repository.GetDiagnosisDataSource(ctx, req.ProjectId, req.DiagnosisDataSourceId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get DiagnosisDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get DiagnosisDataSource, error: %v", err)
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (s *DiagnosisService) PutDiagnosisDataSource(ctx context.Context, req *diag
 	savedData, err := s.repository.GetDiagnosisDataSource(ctx, req.ProjectId, req.DiagnosisDataSource.DiagnosisDataSourceId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get DiagnosisDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get DiagnosisDataSource, error: %v", err)
 		return nil, err
 	}
 
@@ -67,7 +67,7 @@ func (s *DiagnosisService) PutDiagnosisDataSource(ctx context.Context, req *diag
 
 	registerdData, err := s.repository.UpsertDiagnosisDataSource(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put DiagnosisDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put DiagnosisDataSource, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutDiagnosisDataSourceResponse{DiagnosisDataSource: convertDiagnosisDataSource(registerdData)}, nil
@@ -78,7 +78,7 @@ func (s *DiagnosisService) DeleteDiagnosisDataSource(ctx context.Context, req *d
 		return nil, err
 	}
 	if err := s.repository.DeleteDiagnosisDataSource(ctx, req.ProjectId, req.DiagnosisDataSourceId); err != nil {
-		appLogger.Errorf("Failed to Delete DiagnosisDataSource, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete DiagnosisDataSource, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/cmd/diagnosis/services_portscan.go
+++ b/cmd/diagnosis/services_portscan.go
@@ -22,7 +22,7 @@ func (s *DiagnosisService) ListPortscanSetting(ctx context.Context, req *diagnos
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListPortscanSettingResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List PortscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List PortscanSetting, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListPortscanSettingResponse{}
@@ -39,7 +39,7 @@ func (s *DiagnosisService) GetPortscanSetting(ctx context.Context, req *diagnosi
 	getData, err := s.repository.GetPortscanSetting(ctx, req.ProjectId, req.PortscanSettingId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get PortscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get PortscanSetting, error: %v", err)
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func (s *DiagnosisService) PutPortscanSetting(ctx context.Context, req *diagnosi
 	savedData, err := s.repository.GetPortscanSetting(ctx, req.ProjectId, req.PortscanSetting.PortscanSettingId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get PortscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get PortscanSetting, error: %v", err)
 		return nil, err
 	}
 
@@ -70,7 +70,7 @@ func (s *DiagnosisService) PutPortscanSetting(ctx context.Context, req *diagnosi
 
 	registerdData, err := s.repository.UpsertPortscanSetting(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put PortscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put PortscanSetting, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutPortscanSettingResponse{PortscanSetting: convertPortscanSetting(registerdData)}, nil
@@ -81,12 +81,12 @@ func (s *DiagnosisService) DeletePortscanSetting(ctx context.Context, req *diagn
 		return nil, err
 	}
 	if err := s.repository.DeletePortscanSetting(ctx, req.ProjectId, req.PortscanSettingId); err != nil {
-		appLogger.Errorf("Failed to Delete PortscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete PortscanSetting, error: %v", err)
 		return nil, err
 	}
 	// Delete PortscanTargetBySetting
 	if err := s.repository.DeletePortscanTargetByPortscanSettingID(ctx, req.ProjectId, req.PortscanSettingId); err != nil {
-		appLogger.Errorf("Failed to Delete PortscanTargetByPortscanSettingID, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete PortscanTargetByPortscanSettingID, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil
@@ -101,7 +101,7 @@ func (s *DiagnosisService) ListPortscanTarget(ctx context.Context, req *diagnosi
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListPortscanTargetResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List PortscanTarget, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List PortscanTarget, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListPortscanTargetResponse{}
@@ -118,7 +118,7 @@ func (s *DiagnosisService) GetPortscanTarget(ctx context.Context, req *diagnosis
 	getData, err := s.repository.GetPortscanTarget(ctx, req.ProjectId, req.PortscanTargetId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get PortscanTarget, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get PortscanTarget, error: %v", err)
 		return nil, err
 	}
 
@@ -142,7 +142,7 @@ func (s *DiagnosisService) PutPortscanTarget(ctx context.Context, req *diagnosis
 
 	registerdData, err := s.repository.UpsertPortscanTarget(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put PortscanTarget, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put PortscanTarget, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutPortscanTargetResponse{PortscanTarget: convertPortscanTarget(registerdData)}, nil
@@ -153,7 +153,7 @@ func (s *DiagnosisService) DeletePortscanTarget(ctx context.Context, req *diagno
 		return nil, err
 	}
 	if err := s.repository.DeletePortscanTarget(ctx, req.ProjectId, req.PortscanTargetId); err != nil {
-		appLogger.Errorf("Failed to Delete PortscanTarget, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete PortscanTarget, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/cmd/diagnosis/services_wpscan_setting.go
+++ b/cmd/diagnosis/services_wpscan_setting.go
@@ -22,7 +22,7 @@ func (s *DiagnosisService) ListWpscanSetting(ctx context.Context, req *diagnosis
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return &diagnosis.ListWpscanSettingResponse{}, nil
 		}
-		appLogger.Errorf("Failed to List WpscanSettinng, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to List WpscanSettinng, error: %v", err)
 		return nil, err
 	}
 	data := diagnosis.ListWpscanSettingResponse{}
@@ -39,7 +39,7 @@ func (s *DiagnosisService) GetWpscanSetting(ctx context.Context, req *diagnosis.
 	getData, err := s.repository.GetWpscanSetting(ctx, req.ProjectId, req.WpscanSettingId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get WpscanSettinng, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get WpscanSettinng, error: %v", err)
 		return nil, err
 	}
 
@@ -53,7 +53,7 @@ func (s *DiagnosisService) PutWpscanSetting(ctx context.Context, req *diagnosis.
 	savedData, err := s.repository.GetWpscanSetting(ctx, req.ProjectId, req.WpscanSetting.WpscanSettingId)
 	noRecord := errors.Is(err, gorm.ErrRecordNotFound)
 	if err != nil && !noRecord {
-		appLogger.Errorf("Failed to Get WpscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Get WpscanSetting, error: %v", err)
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (s *DiagnosisService) PutWpscanSetting(ctx context.Context, req *diagnosis.
 
 	registerdData, err := s.repository.UpsertWpscanSetting(ctx, data)
 	if err != nil {
-		appLogger.Errorf("Failed to Put WpscanSetting, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Put WpscanSetting, error: %v", err)
 		return nil, err
 	}
 	return &diagnosis.PutWpscanSettingResponse{WpscanSetting: convertWpscanSetting(registerdData)}, nil
@@ -85,7 +85,7 @@ func (s *DiagnosisService) DeleteWpscanSetting(ctx context.Context, req *diagnos
 		return nil, err
 	}
 	if err := s.repository.DeleteWpscanSetting(ctx, req.ProjectId, req.WpscanSettingId); err != nil {
-		appLogger.Errorf("Failed to Delete WpscanSettinng, error: %v", err)
+		appLogger.Errorf(ctx, "Failed to Delete WpscanSettinng, error: %v", err)
 		return nil, err
 	}
 	return &empty.Empty{}, nil


### PR DESCRIPTION
diagnosisサービスのみログとトレースの統合を対応しました。
アクセスログに同様の処理を行うためインタセプターの順序を入れ替えています。

worker系のサービスはaws-sdk-goのバージョンアップが必要になるため、別のPRに切り出す予定です。