### PR TITLE
fix tag finding

### DIFF
--- a/cmd/applicationscan/finding.go
+++ b/cmd/applicationscan/finding.go
@@ -49,8 +49,8 @@ func (s *sqsHandler) putFindings(ctx context.Context, zapResult *zapResult, msg 
 				appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", common.TagVulnerability, err)
 				return err
 			}
-			if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, target); err != nil {
-				appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", target, err)
+			if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, fmt.Sprintf("application_scan_id:%v", msg.ApplicationScanID)); err != nil {
+				appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", fmt.Sprintf("application_scan_id:%v", msg.ApplicationScanID), err)
 				return err
 			}
 			if err = s.putRecommend(ctx, res.Finding.ProjectId, res.Finding.FindingId, msg.DataSource, &alert); err != nil {

--- a/cmd/applicationscan/handler.go
+++ b/cmd/applicationscan/handler.go
@@ -89,7 +89,7 @@ func (s *sqsHandler) HandleMessage(ctx context.Context, sqsMsg *types.Message) e
 	if _, err := s.findingClient.ClearScore(ctx, &finding.ClearScoreRequest{
 		DataSource: msg.DataSource,
 		ProjectId:  msg.ProjectID,
-		Tag:        []string{setting.Target},
+		Tag:        []string{fmt.Sprintf("application_scan_id:%v", msg.ApplicationScanID)},
 	}); err != nil {
 		appLogger.Errorf(ctx, "Failed to clear finding score. ApplicationScanID: %v, error: %v", msg.ApplicationScanID, err)
 		return s.handleErrorWithUpdateStatus(ctx, msg, err)


### PR DESCRIPTION
スキャン対象のURL長が65以上の場合にtagFindingに失敗するため登録するFinding内容をIDに変更します
合わせてclearScoreで指定するタグも変更します