### PR TITLE
Improve error handling in applicationscan

### DIFF
--- a/cmd/applicationscan/applicationscan.go
+++ b/cmd/applicationscan/applicationscan.go
@@ -53,7 +53,7 @@ func (c *applicationScanClient) executeZap(ctx context.Context, apiKeyValue stri
 		return 0, err
 	}
 	pID := cmd.Process.Pid
-	err = c.WaitForStartingZap()
+	err = c.WaitForStartingZap(ctx)
 	if err != nil {
 		appLogger.Errorf(ctx, "Failed to execute ZAP. cmd: %v, error: %v", cmd, err)
 		return 0, err

--- a/cmd/applicationscan/client.go
+++ b/cmd/applicationscan/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Faild to get GRPC connection. error: %v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection. error: %w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Faild to get GRPC connection. error: %v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection. error: %w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newDiagnosisClient(svcAddr string) diagnosis.DiagnosisServiceClient {
-	ctx := context.Background()
+func newDiagnosisClient(ctx context.Context, svcAddr string) (diagnosis.DiagnosisServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Faild to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return diagnosis.NewDiagnosisServiceClient(conn)
+	return diagnosis.NewDiagnosisServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/cmd/applicationscan/finding.go
+++ b/cmd/applicationscan/finding.go
@@ -19,6 +19,7 @@ func (s *sqsHandler) putFindings(ctx context.Context, zapResult *zapResult, msg 
 			data, err := json.Marshal(map[string]zapResultAlert{"data": alert})
 			if err != nil {
 				appLogger.Errorf(ctx, "Failed to marshal zapResult for makeFinding. err: %v", err)
+				return err
 			}
 			res, err := s.findingClient.PutFinding(ctx, &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{
 				Description:      getDescription(&alert, target),

--- a/cmd/applicationscan/handler_scan.go
+++ b/cmd/applicationscan/handler_scan.go
@@ -93,15 +93,16 @@ func (c *applicationScanClient) HandleSpiderScan(ctx context.Context, contextNam
 			appLogger.Errorf(ctx, "Failed to get status spider, error: %v", err)
 			return err
 		}
-		if retSpiderStatus["status"] == nil {
+		status := retSpiderStatus["status"]
+		if status == nil {
 			err = errors.New("SpiderScanStatus is null")
 			appLogger.Errorf(ctx, "Failed to get spider scan status, error: %v", err)
 			return err
 		}
-		spiderStatus, err := strconv.Atoi(retSpiderStatus["status"].(string))
+		spiderStatus, err := strconv.Atoi(status.(string))
 		if err != nil {
-			appLogger.Errorf(ctx, "Failed to convert spider status. error: %v", err)
-			break
+			appLogger.Errorf(ctx, "Failed to convert spider status to int. status: %v, error: %v", status, err)
+			return fmt.Errorf("invalid spider status. err: %w", err)
 		}
 		if spiderStatus >= 100 {
 			break
@@ -129,15 +130,16 @@ func (c *applicationScanClient) HandleActiveScan(ctx context.Context) error {
 			appLogger.Errorf(ctx, "Failed to get active scan status, error: %v", err)
 			return err
 		}
-		if retAscanStatus["status"] == nil {
+		status := retAscanStatus["status"]
+		if status == nil {
 			err = errors.New("ActiveScanStatus is null")
 			appLogger.Errorf(ctx, "Failed to get active scan status, error: %v", err)
 			return err
 		}
-		ascanStatus, err := strconv.Atoi(retAscanStatus["status"].(string))
+		ascanStatus, err := strconv.Atoi(status.(string))
 		if err != nil {
-			appLogger.Errorf(ctx, "Failed to convert active scan status. error: %v", err)
-			break
+			appLogger.Errorf(ctx, "Failed to convert active scan status to int. status: %v, error: %v", status, err)
+			return fmt.Errorf("invalid active scan status. err: %w", err)
 		}
 		if ascanStatus >= 100 {
 			break

--- a/cmd/applicationscan/main.go
+++ b/cmd/applicationscan/main.go
@@ -124,7 +124,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the ApplicationScan SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/cmd/applicationscan/main.go
+++ b/cmd/applicationscan/main.go
@@ -85,18 +85,31 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
+	findingClient, err := newFindingClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	appLogger.Info(ctx, "Start Finding Client")
+	alertClient, err := newAlertClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	appLogger.Info(ctx, "Start Alert Client")
+	diagnosisClient, err := newDiagnosisClient(ctx, conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create diagnosis client, err=%+v", err)
+	}
+	appLogger.Info(ctx, "Start Diagnosis Client")
 	handler := &sqsHandler{
 		zapPort:         conf.ZapPort,
 		zapPath:         conf.ZapPath,
 		zapApiKeyName:   conf.ZapApiKeyName,
 		zapApiKeyHeader: conf.ZapApiKeyHeader,
+		findingClient:   findingClient,
+		alertClient:     alertClient,
+		diagnosisClient: diagnosisClient,
 	}
-	handler.findingClient = newFindingClient(conf.CoreAddr)
-	appLogger.Info(ctx, "Start Finding Client")
-	handler.alertClient = newAlertClient(conf.CoreAddr)
-	appLogger.Info(ctx, "Start Alert Client")
-	handler.diagnosisClient = newDiagnosisClient(conf.DataSourceAPISvcAddr)
-	appLogger.Info(ctx, "Start Diagnosis Client")
+
 	f, err := mimosasqs.NewFinalizer(message.DataSourceNameApplicationScan, settingURL, conf.CoreAddr, nil)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)

--- a/cmd/applicationscan/sqs.go
+++ b/cmd/applicationscan/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,14 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new sqs client, %w", err)
 	}
 
 	return &worker.Worker{
@@ -38,5 +39,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }

--- a/cmd/applicationscan/zap.go
+++ b/cmd/applicationscan/zap.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	//	"context"
-
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -124,17 +123,20 @@ func (c *applicationScanClient) Jsonreport() ([]byte, error) {
 	return c.RequestOther("core/other/jsonreport/", nil)
 }
 
-func (c *applicationScanClient) WaitForStartingZap() error {
+func (c *applicationScanClient) WaitForStartingZap(ctx context.Context) error {
 	WaitDuration := 300.0
 	now := time.Now()
+	count := 1
 	for {
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Second * 20)
 		_, err := c.RequestOther("", nil)
 		if err == nil {
 			return nil
 		}
+		appLogger.Infof(ctx, "Waiting to start ZAP. wait time: %d [sec], err: %+v", count*20, err)
 		if time.Since(now).Seconds() > WaitDuration {
 			return fmt.Errorf("ZAP doesn't start. waitDuration: %v", WaitDuration)
 		}
+		count++
 	}
 }


### PR DESCRIPTION
cmd/applicationscan配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* いくつかの処理が失敗した場合にエラーを返すようにしました。
* zapの起動中のログを出力するようにしました。