### PR TITLE
Improve error handling in portscan

### DIFF
--- a/cmd/portscan/client.go
+++ b/cmd/portscan/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newDiagnosisClient(svcAddr string) diagnosis.DiagnosisServiceClient {
-	ctx := context.Background()
+func newDiagnosisClient(ctx context.Context, svcAddr string) (diagnosis.DiagnosisServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to get GRPC connection: err=%+v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection: err=%w", err)
 	}
-	return diagnosis.NewDiagnosisServiceClient(conn)
+	return diagnosis.NewDiagnosisServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/cmd/portscan/finding.go
+++ b/cmd/portscan/finding.go
@@ -108,6 +108,7 @@ func (s *sqsHandler) putFinding(ctx context.Context, f *finding.FindingForUpsert
 	}
 	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, common.TagFQDN); err != nil {
 		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", common.TagFQDN, err)
+		return nil, err
 	}
 	if err = s.tagFinding(ctx, res.Finding.ProjectId, res.Finding.FindingId, common.TagPortscan); err != nil {
 		appLogger.Errorf(ctx, "Failed to tag finding. tag: %v, error: %v", common.TagPortscan, err)

--- a/cmd/portscan/main.go
+++ b/cmd/portscan/main.go
@@ -111,7 +111,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the portscan SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/cmd/portscan/main.go
+++ b/cmd/portscan/main.go
@@ -79,10 +79,24 @@ func main() {
 	tracer.Start(tc)
 	defer tracer.Stop()
 
-	handler := &sqsHandler{}
-	handler.findingClient = newFindingClient(conf.CoreAddr)
-	handler.alertClient = newAlertClient(conf.CoreAddr)
-	handler.diagnosisClient = newDiagnosisClient(conf.DataSourceAPISvcAddr)
+	findingClient, err := newFindingClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create finding client, err=%+v", err)
+	}
+	alertClient, err := newAlertClient(ctx, conf.CoreAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create alert client, err=%+v", err)
+	}
+	diagnosisClient, err := newDiagnosisClient(ctx, conf.DataSourceAPISvcAddr)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create diagnosis client, err=%+v", err)
+	}
+	handler := &sqsHandler{
+		findingClient:   findingClient,
+		alertClient:     alertClient,
+		diagnosisClient: diagnosisClient,
+	}
+
 	f, err := mimosasqs.NewFinalizer(message.DataSourceNamePortScan, settingURL, conf.CoreAddr, nil)
 	if err != nil {
 		appLogger.Fatalf(ctx, "Failed to create Finalizer, err=%+v", err)

--- a/cmd/portscan/sqs.go
+++ b/cmd/portscan/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
@@ -19,15 +20,14 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(conf *SQSConfig) *worker.Worker {
-	ctx := context.Background()
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	if conf.Debug == "true" {
 		appLogger.Level(logging.DebugLevel)
 	}
 
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.SQSEndpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 
 	return &worker.Worker{
@@ -39,5 +39,5 @@ func newSQSConsumer(conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
cmd/portscan配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしています。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* finding_tagの登録/更新に失敗した場合にエラーを返すようにしました。