### PR TITLE
Improve error handling in wpscan

### DIFF
--- a/cmd/wpscan/client.go
+++ b/cmd/wpscan/client.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ca-risken/core/proto/alert"
@@ -11,31 +12,28 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func newFindingClient(svcAddr string) finding.FindingServiceClient {
-	ctx := context.Background()
+func newFindingClient(ctx context.Context, svcAddr string) (finding.FindingServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Failed to get GRPC connection. error: %v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection. error: %w", err)
 	}
-	return finding.NewFindingServiceClient(conn)
+	return finding.NewFindingServiceClient(conn), nil
 }
 
-func newAlertClient(svcAddr string) alert.AlertServiceClient {
-	ctx := context.Background()
+func newAlertClient(ctx context.Context, svcAddr string) (alert.AlertServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Failed to get GRPC connection. error: %v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection. error: %w", err)
 	}
-	return alert.NewAlertServiceClient(conn)
+	return alert.NewAlertServiceClient(conn), nil
 }
 
-func newDiagnosisClient(svcAddr string) diagnosis.DiagnosisServiceClient {
-	ctx := context.Background()
+func newDiagnosisClient(ctx context.Context, svcAddr string) (diagnosis.DiagnosisServiceClient, error) {
 	conn, err := getGRPCConn(ctx, svcAddr)
 	if err != nil {
-		appLogger.Errorf(ctx, "Failed to get GRPC connection. error: %v", err)
+		return nil, fmt.Errorf("failed to get GRPC connection. error: %w", err)
 	}
-	return diagnosis.NewDiagnosisServiceClient(conn)
+	return diagnosis.NewDiagnosisServiceClient(conn), nil
 }
 
 func getGRPCConn(ctx context.Context, addr string) (*grpc.ClientConn, error) {

--- a/cmd/wpscan/main.go
+++ b/cmd/wpscan/main.go
@@ -127,7 +127,10 @@ func main() {
 		MaxNumberOfMessage: conf.MaxNumberOfMessage,
 		WaitTimeSecond:     conf.WaitTimeSecond,
 	}
-	consumer := newSQSConsumer(ctx, sqsConf)
+	consumer, err := newSQSConsumer(ctx, sqsConf)
+	if err != nil {
+		appLogger.Fatalf(ctx, "Failed to create SQS consumer, err=%+v", err)
+	}
 	appLogger.Info(ctx, "Start the wpscan SQS consumer server...")
 	consumer.Start(ctx,
 		mimosasqs.InitializeHandler(

--- a/cmd/wpscan/sqs.go
+++ b/cmd/wpscan/sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ca-risken/go-sqs-poller/worker/v5"
 )
@@ -16,10 +17,10 @@ type SQSConfig struct {
 	WaitTimeSecond     int32
 }
 
-func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
+func newSQSConsumer(ctx context.Context, conf *SQSConfig) (*worker.Worker, error) {
 	client, err := worker.CreateSqsClient(ctx, conf.AWSRegion, conf.Endpoint)
 	if err != nil {
-		appLogger.Fatalf(ctx, "Failed to create a new client, %v", err)
+		return nil, fmt.Errorf("failed to create a new SQS client, %w", err)
 	}
 
 	return &worker.Worker{
@@ -31,5 +32,5 @@ func newSQSConsumer(ctx context.Context, conf *SQSConfig) *worker.Worker {
 		},
 		Log:       appLogger,
 		SqsClient: client,
-	}
+	}, nil
 }


### PR DESCRIPTION
cmd/wpscan配下のエラーハンドリング改善しました。

* client生成時のエラーは呼び出し元でハンドリングするために呼び出し元に返すようにしました。
* handleErrorWithUpdateStatusはステータスの更新とエラーのラッピングという二つの責務を持っていたので、見通しをよくするために分割しました。責務に合わせてメソッド名も変更しています。
* wpscan.goの処理でエラーが発生した場合にエラーを返すようにしました。