### PR TITLE
Return error when failed to portscan

### DIFF
--- a/cmd/portscan/go.mod
+++ b/cmd/portscan/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.18.5
 	github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b
-	github.com/ca-risken/common/pkg/portscan v0.0.0-20220808083611-4df285e3e690
+	github.com/ca-risken/common/pkg/portscan v0.0.0-20220829042458-b91c9aded6f1
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b
 	github.com/ca-risken/common/pkg/sqs v0.0.0-20220525094706-413e91572a52
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220601065422-5b97bd6efc9b

--- a/cmd/portscan/go.sum
+++ b/cmd/portscan/go.sum
@@ -137,8 +137,8 @@ github.com/ca-risken/common/pkg/logging v0.0.0-20220517105456-de734080357a/go.mo
 github.com/ca-risken/common/pkg/logging v0.0.0-20220518032134-ad443b601efd/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b h1:qNttEBJBsXg68Kzj0+9rw7c52L9rhgaChZOyUO/A4VQ=
 github.com/ca-risken/common/pkg/logging v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:iqLbvDuf708TWjF8RO5qw6Nx1e3R0/UEHZ8tE/VEPjA=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220808083611-4df285e3e690 h1:y/h3PBFl9wbP7p6VeTSEXFufpb3TTh1frd5ResIKaEs=
-github.com/ca-risken/common/pkg/portscan v0.0.0-20220808083611-4df285e3e690/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20220829042458-b91c9aded6f1 h1:CPaN0UHPoLr8S/Cof5q73GPunL7dhwFLN43S1AphRHs=
+github.com/ca-risken/common/pkg/portscan v0.0.0-20220829042458-b91c9aded6f1/go.mod h1:Fa8YzcvEpZJWQNYLI+toBvuD8o4wwEnvk5oOH6nLCrA=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b h1:S3vrpeI7invfVyBw0PhZ15/A/kIV9AOPTXpc+e7RQdU=
 github.com/ca-risken/common/pkg/profiler v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:xldq3VZ7qomkI5vfpw8Y9qCVEFl8BrSvDr+sxbz32H4=
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220601065422-5b97bd6efc9b/go.mod h1:fnvFF8ESVirs5LV36leyFKf3FbuqjLDhJnipGJgDZtA=

--- a/cmd/portscan/portscan.go
+++ b/cmd/portscan/portscan.go
@@ -37,16 +37,7 @@ func (p *portscanClient) scan(ctx context.Context) ([]*portscan.NmapResult, erro
 	for _, target := range p.target {
 		results, err := portscan.Scan(target.Target, target.Protocol, target.FromPort, target.ToPort)
 		if err != nil {
-			appLogger.Warnf(ctx, "Error occured when scanning. err: %v", err)
-			// TODO 以下を確認したら、エラーの種類によるハンドリングはせずにそのまま呼び出し元に返すように変更する予定
-			// 握りつぶしていたエラーを返すようにしたが、そのエラーがどれくらい発生していたかが不明なためそのままエラーを返すとオペレーションの負荷が高くなる可能性がある。
-			// 発生件数を確認するためにログ出力だけを行いエラーは返さずに終了させる。
-			if _, ok := err.(*portscan.ResultAnalysisError); ok {
-				appLogger.Warnf(ctx, "Failed to analyze portscan results, err=%+v", err)
-				return nmapResults, nil
-			} else {
-				return nmapResults, err
-			}
+			return nil, err
 		}
 		for _, result := range results {
 			result.ResourceName = target.Target


### PR DESCRIPTION
common/pkg/portscanのScan失敗時に返すエラーの型を変更したのでその対応です。
確認用に追加した型のエラーは検出されなかったので一律発生したエラーを返すようにしました。