### PR TITLE
fix additional finding score

### DIFF
--- a/cmd/portscan/finding.go
+++ b/cmd/portscan/finding.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ca-risken/diagnosis/pkg/common"
 )
 
+const (
+	MaxScore = 10.0
+)
+
 func (s *sqsHandler) putNmapFinding(ctx context.Context, nmapResult *portscan.NmapResult, projectID uint32, dataSource, data string, target string) error {
 	putFinding := &finding.FindingForUpsert{
 		Description:      nmapResult.GetDescription(),
@@ -19,7 +23,7 @@ func (s *sqsHandler) putNmapFinding(ctx context.Context, nmapResult *portscan.Nm
 		ResourceName:     nmapResult.ResourceName,
 		ProjectId:        projectID,
 		OriginalScore:    nmapResult.GetScore(),
-		OriginalMaxScore: 10.0,
+		OriginalMaxScore: MaxScore,
 		Data:             data,
 	}
 	resFinding, err := s.putFinding(ctx, putFinding, target)
@@ -55,7 +59,7 @@ func (s *sqsHandler) putAdditionalFinding(ctx context.Context, nmapResult *ports
 			ResourceName:     nmapResult.ResourceName,
 			ProjectId:        projectID,
 			OriginalScore:    additionalCheckResult.GetScore(),
-			OriginalMaxScore: 10.0,
+			OriginalMaxScore: MaxScore,
 			Data:             data,
 		}
 		resFinding, err := s.putFinding(ctx, addFinding, target)

--- a/cmd/portscan/finding.go
+++ b/cmd/portscan/finding.go
@@ -55,7 +55,7 @@ func (s *sqsHandler) putAdditionalFinding(ctx context.Context, nmapResult *ports
 			ResourceName:     nmapResult.ResourceName,
 			ProjectId:        projectID,
 			OriginalScore:    additionalCheckResult.GetScore(),
-			OriginalMaxScore: 1.0,
+			OriginalMaxScore: 10.0,
 			Data:             data,
 		}
 		resFinding, err := s.putFinding(ctx, addFinding, target)


### PR DESCRIPTION
open proxy等の危険な状態のスコアが8.0なのに対して、OriginalMaxScoreが1.0となっていた
Finding登録エラーとなることを修正するために10.0に修正
Finding画面では、0.8と出力されるようになる