### PR TITLE
fix: env-injector build

### DIFF
--- a/cmd/applicationscan/Dockerfile
+++ b/cmd/applicationscan/Dockerfile
@@ -1,26 +1,19 @@
 FROM golang:1.18.2 AS builder
-
 WORKDIR /go/src/github.com/ca-risken/diagnosis/cmd/applicationscan/
-
 ADD *.go go.* ./
-ARG ENV_INJECTOR_VERSION=v0.0.6
-ARG GITHUB_USER
-ARG GITHUB_TOKEN
-RUN echo "machine github.com" > ~/.netrc
-RUN echo "login $GITHUB_USER" >> ~/.netrc
-RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/
 
 WORKDIR /go/src/github.com/gassara-kys
+ARG ENV_INJECTOR_VERSION=v0.0.6
 RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
   && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
+  && go mod download \
+  && CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/
 
 FROM public.ecr.aws/w4a9j2y8/diagnosis/applicationscan-base:v2.10.0
 COPY --from=builder /go/bin/env-injector /usr/local/bin/
-COPY --from=builder /go/bin/applicationscan /usr/local/applicationscan/bin/
+COPY --from=builder /go/bin/applicationscan /usr/local/bin/
 ENV DEBUG= \
   PROFILE_EXPORTER= \
   PROFILE_TYPES= \
@@ -39,6 +32,6 @@ ENV DEBUG= \
   AWS_SVC_ADDR= \
   ZAP_PORT= \
   TZ=Asia/Tokyo
-WORKDIR /usr/local/applicationscan
-ENTRYPOINT ["/usr/local/bin/env-injector"]
+WORKDIR /usr/local/
+ENTRYPOINT ["bin/env-injector"]
 CMD ["bin/applicationscan"]

--- a/cmd/portscan/Dockerfile
+++ b/cmd/portscan/Dockerfile
@@ -1,19 +1,12 @@
 FROM golang:1.18.2 AS builder
-
 WORKDIR /go/src/github.com/ca-risken/diagnosis/cmd/portscan/
-
 ADD *.go go.* ./
-ARG GITHUB_USER
-ARG GITHUB_TOKEN
-RUN echo "machine github.com" > ~/.netrc
-RUN echo "login $GITHUB_USER" >> ~/.netrc
-RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/
 
 FROM public.ecr.aws/risken/base/risken-base:v0.0.1
 RUN apk add --no-cache nmap nmap-scripts
-COPY --from=builder /go/bin/portscan /usr/local/portscan/bin/
+COPY --from=builder /go/bin/portscan /usr/local/bin/
 ENV DEBUG= \
   PROFILE_EXPORTER= \
   PROFILE_TYPES= \
@@ -31,6 +24,6 @@ ENV DEBUG= \
   ALERT_SVC_ADDR= \
   AWS_SVC_ADDR= \
   TZ=Asia/Tokyo
-WORKDIR /usr/local/portscan
-ENTRYPOINT ["/usr/local/bin/env-injector"]
+WORKDIR /usr/local/
+ENTRYPOINT ["bin/env-injector"]
 CMD ["bin/portscan"]

--- a/cmd/wpscan/Dockerfile
+++ b/cmd/wpscan/Dockerfile
@@ -1,28 +1,21 @@
 FROM golang:1.18.2 AS builder
-
-WORKDIR /go/src/github.com/ca-risken/diagnosis/src/wpscan/
-
+WORKDIR /go/src/github.com/ca-risken/diagnosis/cmd/wpscan/
 ADD *.go go.* ./
-ARG ENV_INJECTOR_VERSION=v0.0.6
-ARG GITHUB_USER
-ARG GITHUB_TOKEN
-RUN echo "machine github.com" > ~/.netrc
-RUN echo "login $GITHUB_USER" >> ~/.netrc
-RUN echo "password $GITHUB_TOKEN" >> ~/.netrc
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/
 
 WORKDIR /go/src/github.com/gassara-kys
+ARG ENV_INJECTOR_VERSION=v0.0.6
 RUN git clone https://github.com/gassara-kys/env-injector.git -b ${ENV_INJECTOR_VERSION} \
   && cd env-injector \
-  && go build \
-  && cp env-injector /go/bin/
+  && go mod download \
+  && CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /go/bin/
 
 FROM public.ecr.aws/risken/risken-diagnosis/wpscan-base:v3.8.18
 USER root 
 RUN apk add --no-cache ca-certificates tzdata
 COPY --from=builder /go/bin/env-injector /usr/local/bin/
-COPY --from=builder /go/bin/wpscan /usr/local/wpscan/bin/
+COPY --from=builder /go/bin/wpscan /usr/local/bin/
 ENV PORT=19003 \
   PROFILE_EXPORTER= \
   PROFILE_TYPES= \
@@ -42,6 +35,6 @@ ENV PORT=19003 \
   WPSCAN_VULNDB_APIKEY= \
   TZ=Asia/Tokyo
 
-WORKDIR /usr/local/wpscan
-ENTRYPOINT ["/usr/local/bin/env-injector"]
+WORKDIR /usr/local/
+ENTRYPOINT ["bin/env-injector"]
 CMD ["bin/wpscan"]

--- a/codebuild/multi-arch/buildspec-image.yml
+++ b/codebuild/multi-arch/buildspec-image.yml
@@ -5,17 +5,10 @@ env:
     DOCKER_BUILDKIT: "1"
     IMAGE_PREFIX: "risken-diagnosis"
   parameter-store:
-    GITHUB_USER: "/build/GITHUB_USER"
-    GITHUB_TOKEN: "/build/GITHUB_TOKEN"
     DOCKER_USER: "/build/DOCKER_USER"
     DOCKER_TOKEN: "/build/DOCKER_TOKEN"
 
 phases:
-  install:
-    commands:
-      - echo "machine github.com" > ~/.netrc
-      - echo "login ${GITHUB_USER}" >> ~/.netrc
-      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
   pre_build:
     commands:
       - echo Setting environment variables

--- a/codebuild/release/buildspec-image.yml
+++ b/codebuild/release/buildspec-image.yml
@@ -5,16 +5,8 @@ env:
     PRIVATE_IMAGE_PREFIX: 'risken-diagnosis'
     PUBLIC_REGISTRY: 'public.ecr.aws/risken'
     PUBLIC_IMAGE_PREFIX: 'diagnosis'
-  parameter-store:
-    GITHUB_USER: '/build/GITHUB_USER'
-    GITHUB_TOKEN: '/build/GITHUB_TOKEN'
 
 phases:
-  install:
-    commands:
-      - echo "machine github.com" > ~/.netrc
-      - echo "login ${GITHUB_USER}" >> ~/.netrc
-      - echo "password ${GITHUB_TOKEN}" >> ~/.netrc
   pre_build:
     commands:
       - echo Setting environment variables

--- a/hack/docker-build.sh
+++ b/hack/docker-build.sh
@@ -5,4 +5,4 @@ fi
 if [ "${IMAGE_PREFIX}" = "" ]; then
   IMAGE_PREFIX=default_prefix
 fi
-cd cmd/${TARGET} && docker build ${BUILD_OPT} --build-arg GITHUB_USER=${GITHUB_USER} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t ${IMAGE_PREFIX}/${TARGET}:${IMAGE_TAG} .
+cd cmd/${TARGET} && docker build ${BUILD_OPT} -t ${IMAGE_PREFIX}/${TARGET}:${IMAGE_TAG} .


### PR DESCRIPTION
ENTRYPOINTに指定している env-injector が存在せず以下のエラーが発生していた。

```
standard_init_linux.go:228: exec user process caused: no such file or directory
```

go 1.18のアップグレードに伴いビルド箇所を修正。

また、不要なgithubのTokenを削除（OSS化したので不要だが消し忘れで残っていた）